### PR TITLE
Migrate from pyautogen to ag2 Library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ jiter==0.5.0
 numpy==1.26.4
 openai==1.43.0
 packaging==24.1
-pyautogen==0.2.35
+ag2==0.2.35
 pydantic==2.8.2
 pydantic_core==2.20.1
 python-dotenv==1.0.1


### PR DESCRIPTION
### **User description**
Hey there! This is AG2 👋

First of all, thank you for using pyautogen! We've seen you're using pyautogen, and we're here to help you migrate to ag2.

This pull request is designed to help update this codebase by smoothly transitioning from the `pyautogen` library to the new `ag2` library.

Why the change? `pyautogen` is being deprecated, and `ag2` is now the recommended successor for ongoing development. 

The good news is, **there is no syntax difference between pyautogen and ag2** – this migration primarily involves updating library imports and usage.

This update will ensure the project stays compatible with the latest tools and can benefit from all the improvements in the ag2 ecosystem.

Could you please take a moment to review and merge this at your earliest convenience? Your collaboration is much appreciated! Thank you!


___

### **PR Type**
Other


___

### **Description**
- Replace `pyautogen` dependency with `ag2` library

- Update requirements.txt to use ag2==0.2.35


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pyautogen["pyautogen==0.2.35"] -- "migrate to" --> ag2["ag2==0.2.35"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>requirements.txt</strong><dd><code>Update dependency from pyautogen to ag2</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

requirements.txt

- Replace `pyautogen==0.2.35` with `ag2==0.2.35` dependency


</details>


  </td>
  <td><a href="https://github.com/hackertron/TLSN-plugin-gen/pull/6/files#diff-4d7c51b1efe9043e44439a949dfd92e5827321b34082903477fd04876edb7552">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

